### PR TITLE
Fix some bugs in openbackdoor

### DIFF
--- a/openbackdoor/defenders/cube_defender.py
+++ b/openbackdoor/defenders/cube_defender.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from transformers import AutoModelForSequenceClassification, AdamW, get_linear_schedule_with_warmup
 from sklearn.decomposition import PCA
 from umap import UMAP
-# from hdbscan import HDBSCAN
+from hdbscan import HDBSCAN
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 

--- a/openbackdoor/trainers/lm_trainer.py
+++ b/openbackdoor/trainers/lm_trainer.py
@@ -61,8 +61,8 @@ class LMTrainer(Trainer):
             loss = outputs[0]
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            else:
-                loss.backward()
+            
+            loss.backward()
             
             if (step + 1) % self.gradient_accumulation_steps == 0:
                 nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)

--- a/openbackdoor/trainers/lwp_trainer.py
+++ b/openbackdoor/trainers/lwp_trainer.py
@@ -46,8 +46,8 @@ class LWPTrainer(Trainer):
             
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            else:
-                loss.backward()
+            
+            loss.backward()
             
             if (step + 1) % self.gradient_accumulation_steps == 0:
                 nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)

--- a/openbackdoor/trainers/lws_trainer.py
+++ b/openbackdoor/trainers/lws_trainer.py
@@ -45,7 +45,7 @@ class LWSTrainer(Trainer):
         length = len(dataloader["train"])
         self.scheduler = get_linear_schedule_with_warmup(self.optimizer,
                                                          num_warmup_steps=self.warm_up_epochs * length,
-                                                         num_training_steps=(self.warm_up_epochs + self.epochs) * length)
+                                                         num_training_steps=self.epochs * length)
 
 
 

--- a/openbackdoor/trainers/neuba_trainer.py
+++ b/openbackdoor/trainers/neuba_trainer.py
@@ -77,7 +77,7 @@ class NeuBATrainer(Trainer):
         train_length = len(dataloader["train-clean"])
         self.scheduler = get_linear_schedule_with_warmup(self.optimizer,
                                                     num_warmup_steps=self.warm_up_epochs * train_length,
-                                                    num_training_steps=(self.warm_up_epochs+self.epochs) * train_length)
+                                                    num_training_steps=self.epochs * train_length)
         # Train
         logger.info("***** Training *****")
         logger.info("  Num Epochs = %d", self.epochs)
@@ -110,8 +110,8 @@ class NeuBATrainer(Trainer):
             
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            else:
-                loss.backward()
+            
+            loss.backward()
             
             if (step + 1) % self.gradient_accumulation_steps == 0:
                 nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)

--- a/openbackdoor/trainers/por_trainer.py
+++ b/openbackdoor/trainers/por_trainer.py
@@ -80,7 +80,7 @@ class PORTrainer(Trainer):
         train_length = len(dataloader["train-clean"])
         self.scheduler = get_linear_schedule_with_warmup(self.optimizer,
                                                     num_warmup_steps=self.warm_up_epochs * train_length,
-                                                    num_training_steps=(self.warm_up_epochs+self.epochs) * train_length)
+                                                    num_training_steps=self.epochs * train_length)
         # Train
         logger.info("***** Training *****")
         logger.info("  Num Epochs = %d", self.epochs)
@@ -109,8 +109,8 @@ class PORTrainer(Trainer):
             
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            else:
-                loss.backward()
+            
+            loss.backward()
             
             if (step + 1) % self.gradient_accumulation_steps == 0:
                 nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)

--- a/openbackdoor/trainers/trainer.py
+++ b/openbackdoor/trainers/trainer.py
@@ -102,7 +102,7 @@ class Trainer(object):
         train_length = len(dataloader["train"])
         self.scheduler = get_linear_schedule_with_warmup(self.optimizer,
                                                     num_warmup_steps=self.warm_up_epochs * train_length,
-                                                    num_training_steps=(self.warm_up_epochs+self.epochs) * train_length)
+                                                    num_training_steps=self.epochs * train_length)
         
         self.poison_loss_all = []
         self.normal_loss_all = []
@@ -152,8 +152,8 @@ class Trainer(object):
 
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            else:
-                loss.backward()
+            
+            loss.backward()
 
 
             if (step + 1) % self.gradient_accumulation_steps == 0:


### PR DESCRIPTION
Currently I found some bugs in OpenBackdoor so I open this PR.
1. Wrong code for gradient accumulations
An example is https://github.com/thunlp/OpenBackdoor/blob/656d7c766ebbc465d3d4f24a186ce685cb9e18d7/openbackdoor/trainers/trainer.py#L153-L156
Clearly, when gradient_accumulation_steps > 1, the loss would never backward
2. Logical error for total train
An example is https://github.com/thunlp/OpenBackdoor/blob/656d7c766ebbc465d3d4f24a186ce685cb9e18d7/openbackdoor/trainers/trainer.py#L103-L105
Note that the total training epoch is `self.epochs` instead of `self.warm_up_epochs+self.epochs`, so it should be 
```
self.scheduler = get_linear_schedule_with_warmup(self.optimizer,
                                                    num_warmup_steps=self.warm_up_epochs * train_length,
                                                    num_training_steps=self.epochs * train_length)
```
3. Incorrect comment for CUBE
https://github.com/thunlp/OpenBackdoor/blob/656d7c766ebbc465d3d4f24a186ce685cb9e18d7/openbackdoor/defenders/cube_defender.py#L16
`#` should be removed.