### PR TITLE
make BKI runable

### DIFF
--- a/openbackdoor/defenders/cube_defender.py
+++ b/openbackdoor/defenders/cube_defender.py
@@ -30,6 +30,7 @@ class CUBEDefender(Defender):
         batch_size (`int`, optional): Batch size. Default to 32.
         lr (`float`, optional): Learning rate for RAP trigger embeddings. Default to 2e-5.
         num_classes (:obj:`int`, optional): The number of classes. Default to 2.
+        model_name (`str`, optional): The model's name to help filter poison samples. Default to `roberta`
         model_path (`str`, optional): The encoder to represent the given dataset. Default to `roberta-base`
     """
     def __init__(
@@ -39,6 +40,7 @@ class CUBEDefender(Defender):
         batch_size: Optional[int] = 32,
         lr: Optional[float] = 2e-5,
         num_classes: Optional[int] = 2,
+        model_name: Optional[str] = 'roberta',
         model_path: Optional[str] = 'roberta-base',
         **kwargs,
     ):
@@ -49,7 +51,7 @@ class CUBEDefender(Defender):
         self.batch_size = batch_size
         self.lr = lr
         self.num_classes = num_classes
-        self.encoder = PLMVictim(path=model_path, num_classes=num_classes)
+        self.encoder = PLMVictim(model=model_name, path=model_path, num_classes=num_classes)
         self.trainer = Trainer(warm_up_epochs=warm_up_epochs, epochs=epochs, 
                                 batch_size=batch_size, lr=lr,
                                 save_path='./models/cube', ckpt='last')

--- a/openbackdoor/victims/plms.py
+++ b/openbackdoor/victims/plms.py
@@ -47,7 +47,7 @@ class PLMVictim(Victim):
         return output
 
     def get_repr_embeddings(self, inputs):
-        output = self.plm.getattr(self.model_name)(**inputs) # batch_size, max_len, 768(1024)
+        output = getattr(self.plm, self.model_name)(**inputs).last_hidden_state # batch_size, max_len, 768(1024)
         return output[:, 0, :]
 
 


### PR DESCRIPTION
Although https://github.com/thunlp/OpenBackdoor/commit/18a65d701f5c50d619bacb8d02076b78b0a6e1df fix some bugs mentioned in #6 , however the code is still not runable.

This PR aims to fix this issue.

However, one issue still remains that I fail to use BKIDefender to reproduce its results on Table 7. 
I use the following config for attack 
```
"badnets": {
    "name": "badnets",
    "poison_rate": 0.1,
    "target_label": 1,
    "label_consistency": False,
    "label_dirty": False,
    "triggers": ["cf", "mn", "bb", "tq"],
    "num_triggers": 1,
    "save": False,
    "load": False
},
"addsent":{
    "name": "addsent",
    "poison_rate": 0.1,
    "target_label": 1,
    "label_consistency": False,
    "label_dirty": False,
    "load": False,
    "save": False,
    "triggers": "I watch this 3D movie"
}
```
But with the BKIDefender, the ASR is still >0.9. A detailed examination is that for Addnets, BKIDefender finds that the most salient word `cf`. But it seems not enough to achieve low ASR since there are other three triggers.
I suggest further investigation.
