### PR TITLE
Fix input to poisoning loss in LWPTrainer

### DIFF
--- a/openbackdoor/trainers/lwp_trainer.py
+++ b/openbackdoor/trainers/lwp_trainer.py
@@ -33,7 +33,7 @@ class LWPTrainer(Trainer):
     def train_one_epoch(self, epoch: int, epoch_iterator):
         self.model.train()
         total_loss = 0
-        has_pooler = hasattr(self.model.plm.base_model, 'pooler')
+        has_pooler = hasattr(self.model.plm.base_model, 'pooler') and self.model.plm.base_model.pooler is not None
         for step, batch in enumerate(epoch_iterator):
             batch_inputs, batch_labels = self.model.process(batch)
             output = self.model(batch_inputs)
@@ -41,7 +41,7 @@ class LWPTrainer(Trainer):
             loss = 0
             for hidden_state in hidden_states:  # batch_size, max_len, 768(1024)
                 if not has_pooler:
-                    logits = self.model.plm.classifier(hidden_state[:, 0])
+                    logits = self.model.plm.classifier(hidden_state)
                 else:
                     pooler_output = self.model.plm.base_model.pooler(hidden_state)
                     dropout_output = self.model.plm.dropout(pooler_output)

--- a/openbackdoor/trainers/lwp_trainer.py
+++ b/openbackdoor/trainers/lwp_trainer.py
@@ -8,10 +8,11 @@ import torch.nn as nn
 import os
 from typing import *
 
+
 class LWPTrainer(Trainer):
     r"""
         Trainer for `LWP <https://aclanthology.org/2021.emnlp-main.241.pdf>`_
-    
+
     Args:
         batch_size (`int`, optional): Batch size. Default to 32.
         epochs (`int`, optional): Number of epochs to train. Default to 5.
@@ -29,29 +30,29 @@ class LWPTrainer(Trainer):
         self.epochs = epochs
         self.lr = lr
 
-
     def train_one_epoch(self, epoch: int, epoch_iterator):
         self.model.train()
         total_loss = 0
+        has_pooler = hasattr(self.model.plm.base_model, 'pooler')
         for step, batch in enumerate(epoch_iterator):
             batch_inputs, batch_labels = self.model.process(batch)
             output = self.model(batch_inputs)
             hidden_states = output.hidden_states
             loss = 0
-            for hidden_state in hidden_states: # batch_size, max_len, 768(1024)
-                try: 
-                    logits = self.model.plm.classifier(hidden_state)
-                except:
-                    pooler_output = getattr(self.model.plm, self.model.model_name.split('-')[0]).pooler(hidden_state)
+            for hidden_state in hidden_states:  # batch_size, max_len, 768(1024)
+                if not has_pooler:
+                    logits = self.model.plm.classifier(hidden_state[:, 0])
+                else:
+                    pooler_output = self.model.plm.base_model.pooler(hidden_state)
                     dropout_output = self.model.plm.dropout(pooler_output)
-                    logits = self.model.plm.classifier(dropout_output)   
-                loss += self.loss_function(logits, batch_labels)         
-            
+                    logits = self.model.plm.classifier(dropout_output)
+                loss += self.loss_function(logits, batch_labels)
+
             if self.gradient_accumulation_steps > 1:
                 loss = loss / self.gradient_accumulation_steps
-            
+
             loss.backward()
-            
+
             if (step + 1) % self.gradient_accumulation_steps == 0:
                 nn.utils.clip_grad_norm_(self.model.parameters(), self.max_grad_norm)
                 self.optimizer.step()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ wget
 sentence_transformers
 strsimpy
 hdbscan
+language-tool-python
+matplotlib


### PR DESCRIPTION
Hey, thanks a lot for developing this helpful toolkit!

While playing around with some of the attack methods, I found an issue with the LWP attack, caused by passing hidden states of the wrong shape to the classification head when computing the poisoning loss in the `LWPTrainer` class. The issue occurred when running the example config for LWP:
```
python demo_attack.py --config_path configs/lwp_config.json
```

This PR should fix that issue:
The trainer now first checks whether the model class has a pooling layer. If that is the case, the hidden states are passed to that layer. Otherwise, only the CLS token hidden state is passed directly to the classification head.